### PR TITLE
Fix stride computation for dimensions with shape 0 in ndarray

### DIFF
--- a/src/ASDF.jl
+++ b/src/ASDF.jl
@@ -798,8 +798,7 @@ function NDArray(
         # zero-shape arrays (e.g. `chisq`, `dumo`) with no explicit `strides` key,
         # triggering this exact failure prior to the fix.
         sz = sizeof(Type(datatype))
-        clamped_shape = [s == 0 ? 1 : s for s in shape[(begin + 1):end]]
-        strides = reverse(cumprod([sz; reverse(clamped_shape)]))
+        strides = reverse(cumprod([sz; reverse(max.(shape[(begin + 1):end], 1))]))
     end
     return NDArray(
         lazy_block_headers, source, data, Vector{Int64}(shape), datatype, byteorder, Int64(offset), Vector{Int64}(strides)

--- a/src/ASDF.jl
+++ b/src/ASDF.jl
@@ -785,18 +785,15 @@ function NDArray(
         offset = 0
     end
     if strides isa Nothing
-        # Calculate byte strides in C order. Any dimension of length zero is treated as
-        # length 1 within this product only (not in `shape` itself); this matches NumPy's
-        # convention for computing default C-contiguous strides (`PyArray_NewFromDescr`),
-        # relied on by the reference Python `asdf` package when constructing arrays via
-        # `np.ndarray(shape, dtype, data, offset, None, order)`. Without the clamp, any
-        # zero-length dimension collapses the strides of every outer dimension whose
+        # Calculate byte strides in C order, treating any zero-length dimension as
+        # length 1 within this product only (not in `shape` itself). This matches NumPy's
+        # convention for default C-contiguous strides (`PyArray_NewFromDescr`),
+        # relied on by the reference Python `asdf` package. Without the clamp, a
+        # zero-length dimension collapses the stride of every outer dimension whose
         # product includes it down to zero, which then fails the `strides` positivity
         # check below even though no data is ever read from a zero-size array. Negative
-        # entries are left unclamped so the `shape` negativity check below still reports
-        # them with its own clear error message. STScI Roman L2 `.asdf` products contain
-        # zero-shape arrays (e.g. `chisq`, `dumo`) with no explicit `strides` key,
-        # triggering this exact failure prior to the fix.
+        # entries are left unclamped so the shape negativity check below still reports them with its own clear error message. STScI Roman L2 `.asdf` products contain such
+        # zero-shape arrays (e.g. `chisq`, `dumo`) with no explicit `strides` key.
         sz = sizeof(Type(datatype))
         strides = reverse(cumprod([sz; reverse(max.(shape[(begin + 1):end], 1))]))
     end

--- a/src/ASDF.jl
+++ b/src/ASDF.jl
@@ -845,7 +845,7 @@ size(result) == Tuple(reverse(ndarray.shape))
 eltype(result) == ASDF.materialized_eltype(ndarray.datatype)
 ```
 
-For the `ucs4` and `ascii` string datatypes, [`materialized_eltype`](@ref) is a thin `AbstractString` view over the characters ([`UCS4String`](@ref) / [`AsciiString`](@ref); see [`stringify_data`](@ref)). For all other datatypes, `eltype(result) == Type(ndarray.datatype)` and additionally, for every dimension with more than one element, `sizeof(eltype) .* strides(result) == Tuple(reverse(ndarray.strides))` along that dimension. (Dimensions of length 0 or 1 have no well-defined stride -- there is no pair of adjacent elements to space apart -- so `reshape`/`reinterpret` are free to report any value there, and such dimensions are excluded from this check.)
+For the `ucs4` and `ascii` string datatypes, [`materialized_eltype`](@ref) is a thin `AbstractString` view over the characters ([`UCS4String`](@ref) / [`AsciiString`](@ref); see [`stringify_data`](@ref)). For all other datatypes, `eltype(result) == Type(ndarray.datatype)` and additionally, when the array has at least one element, `sizeof(eltype) .* strides(result) == Tuple(reverse(ndarray.strides))` along every dimension with more than one element. (A dimension of length 1 has no well-defined stride, there is no pair of adjacent elements to space apart along it, and in a zero-element array no dimension does, so `reshape`/`reinterpret` are free to report any value there; such strides are excluded from this check.)
 """
 function Base.getindex(ndarray::NDArray)
     if ndarray.data !== nothing

--- a/src/ASDF.jl
+++ b/src/ASDF.jl
@@ -785,9 +785,21 @@ function NDArray(
         offset = 0
     end
     if strides isa Nothing
-        # Calculate byte strides in C order
+        # Calculate byte strides in C order. Any dimension of length zero is treated as
+        # length 1 within this product only (not in `shape` itself); this matches NumPy's
+        # convention for computing default C-contiguous strides (`PyArray_NewFromDescr`),
+        # relied on by the reference Python `asdf` package when constructing arrays via
+        # `np.ndarray(shape, dtype, data, offset, None, order)`. Without the clamp, any
+        # zero-length dimension collapses the strides of every outer dimension whose
+        # product includes it down to zero, which then fails the `strides` positivity
+        # check below even though no data is ever read from a zero-size array. Negative
+        # entries are left unclamped so the `shape` negativity check below still reports
+        # them with its own clear error message. STScI Roman L2 `.asdf` products contain
+        # zero-shape arrays (e.g. `chisq`, `dumo`) with no explicit `strides` key,
+        # triggering this exact failure prior to the fix.
         sz = sizeof(Type(datatype))
-        strides = reverse(cumprod([sz; reverse(shape[(begin + 1):end])]))
+        clamped_shape = [s == 0 ? 1 : s for s in shape[(begin + 1):end]]
+        strides = reverse(cumprod([sz; reverse(clamped_shape)]))
     end
     return NDArray(
         lazy_block_headers, source, data, Vector{Int64}(shape), datatype, byteorder, Int64(offset), Vector{Int64}(strides)
@@ -833,7 +845,7 @@ size(result) == Tuple(reverse(ndarray.shape))
 eltype(result) == ASDF.materialized_eltype(ndarray.datatype)
 ```
 
-For the `ucs4` and `ascii` string datatypes, [`materialized_eltype`](@ref) is a thin `AbstractString` view over the characters ([`UCS4String`](@ref) / [`AsciiString`](@ref); see [`stringify_data`](@ref)). For all other datatypes, `eltype(result) == Type(ndarray.datatype)` and additionally `sizeof(eltype) .* strides(result) == Tuple(reverse(ndarray.strides))`.
+For the `ucs4` and `ascii` string datatypes, [`materialized_eltype`](@ref) is a thin `AbstractString` view over the characters ([`UCS4String`](@ref) / [`AsciiString`](@ref); see [`stringify_data`](@ref)). For all other datatypes, `eltype(result) == Type(ndarray.datatype)` and additionally, for every dimension with more than one element, `sizeof(eltype) .* strides(result) == Tuple(reverse(ndarray.strides))` along that dimension. (Dimensions of length 0 or 1 have no well-defined stride -- there is no pair of adjacent elements to space apart -- so `reshape`/`reinterpret` are free to report any value there, and such dimensions are excluded from this check.)
 """
 function Base.getindex(ndarray::NDArray)
     if ndarray.data !== nothing
@@ -870,7 +882,13 @@ function Base.getindex(ndarray::NDArray)
     # Check array layout
     @assert size(data) == Tuple(reverse(ndarray.shape)) # `data` conforms to specified `ndarray.shape`
     @assert eltype(data) == Type(ndarray.datatype) # `data` matches type specified by `ndarray.datatype`
-    if sizeof(eltype(data)) .* Base.strides(data) != Tuple(reverse(ndarray.strides))
+    # Dimensions of length 0 or 1 have no meaningful stride (there is no pair of adjacent
+    # elements to space apart along them), so `reshape`/`reinterpret` are free to report any
+    # value for them; only compare strides along dimensions with more than one element.
+    computed_strides = sizeof(eltype(data)) .* Base.strides(data)
+    expected_strides = Tuple(reverse(ndarray.strides))
+    data_shape = size(data)
+    if any(data_shape[i] > 1 && computed_strides[i] != expected_strides[i] for i in eachindex(data_shape))
         error("`data` has different stride from `ndarray.strides`")
     end
 

--- a/src/ASDF.jl
+++ b/src/ASDF.jl
@@ -882,13 +882,14 @@ function Base.getindex(ndarray::NDArray)
     # Check array layout
     @assert size(data) == Tuple(reverse(ndarray.shape)) # `data` conforms to specified `ndarray.shape`
     @assert eltype(data) == Type(ndarray.datatype) # `data` matches type specified by `ndarray.datatype`
-    # Dimensions of length 0 or 1 have no meaningful stride (there is no pair of adjacent
-    # elements to space apart along them), so `reshape`/`reinterpret` are free to report any
-    # value for them; only compare strides along dimensions with more than one element.
+    # A dimension of length 1 has no meaningful stride (there is no pair of adjacent elements
+    # to space apart along it), and in an empty array no dimension does — Julia reports
+    # stride 0 along any dimension whose faster-varying dimensions include a zero length.
+    # Only compare strides where they are meaningful.
     computed_strides = sizeof(eltype(data)) .* Base.strides(data)
     expected_strides = Tuple(reverse(ndarray.strides))
     data_shape = size(data)
-    if any(data_shape[i] > 1 && computed_strides[i] != expected_strides[i] for i in eachindex(data_shape))
+    if !isempty(data) && any(data_shape[i] > 1 && computed_strides[i] != expected_strides[i] for i in eachindex(data_shape))
         error("`data` has different stride from `ndarray.strides`")
     end
 

--- a/test/test-ndarray.jl
+++ b/test/test-ndarray.jl
@@ -85,6 +85,44 @@ end
     )
 end
 
+@testset "implicit strides with zero-length dimensions" begin
+    # 2026/08/06: Regression test for STScI Roman L2 `.asdf` products produced by romanisim
+    # which contain `!core/ndarray` nodes (e.g. the `chisq`/`dumo` arrays)
+    # with a zero-length shape and no explicit `strides`
+    # key. The naive C-order stride formula (`stride[i] = itemsize * prod(shape[i+1:])`)
+    # collapses to zero for every dimension whose product includes a zero-length axis, which
+    # then fails the `strides` positivity check below even though no data is ever read from a
+    # zero-size array. NumPy avoids this by treating a zero-length axis as though it were
+    # length 1 when computing default C-contiguous strides (`PyArray_NewFromDescr`), which the
+    # reference Python `asdf` package relies on. Expected values below were verified against
+    # `np.ndarray(shape, dtype, buffer, offset, strides=None, order='C').strides`.
+    cases = [
+        (Int64[0, 0], ASDF.Datatype_float16, Int64[2, 2]),
+        (Int64[0, 5], ASDF.Datatype_float32, Int64[20, 4]),
+        (Int64[5, 0], ASDF.Datatype_float32, Int64[4, 4]),
+        (Int64[0, 0, 3], ASDF.Datatype_float32, Int64[12, 12, 4]),
+        (Int64[2, 0, 3], ASDF.Datatype_float32, Int64[12, 12, 4]),
+        (Int64[0, 2, 3], ASDF.Datatype_float32, Int64[24, 12, 4]),
+    ]
+    for (shape, datatype, expected_strides) in cases
+        nd = ASDF.NDArray(
+            ASDF.LazyBlockHeaders(), Int64(0), nothing, shape, datatype, ASDF.host_byteorder, Int64(0), nothing,
+        )
+        @test nd.strides == expected_strides
+    end
+
+    @testset "materializes a zero-size block-backed array" begin
+        lbh = ASDF.LazyBlockHeaders()
+        push!(lbh.block_headers, make_block_header(UInt8[]))
+        nd = ASDF.NDArray(
+            lbh, Int64(0), nothing, Int64[0, 0], ASDF.Datatype_float16, ASDF.host_byteorder, Int64(0), nothing,
+        )
+        arr = nd[]
+        @test size(arr) == (0, 0)
+        @test eltype(arr) == Float16
+    end
+end
+
 @testset "getindex" begin
     opposite = ASDF.host_byteorder == ASDF.Byteorder_little ? ASDF.Byteorder_big : ASDF.Byteorder_little
 

--- a/test/test-ndarray.jl
+++ b/test/test-ndarray.jl
@@ -86,16 +86,11 @@ end
 end
 
 @testset "implicit strides with zero-length dimensions" begin
-    # 2026/08/06: Regression test for STScI Roman L2 `.asdf` products produced by romanisim
-    # which contain `!core/ndarray` nodes (e.g. the `chisq`/`dumo` arrays)
-    # with a zero-length shape and no explicit `strides`
-    # key. The naive C-order stride formula (`stride[i] = itemsize * prod(shape[i+1:])`)
-    # collapses to zero for every dimension whose product includes a zero-length axis, which
-    # then fails the `strides` positivity check below even though no data is ever read from a
-    # zero-size array. NumPy avoids this by treating a zero-length axis as though it were
-    # length 1 when computing default C-contiguous strides (`PyArray_NewFromDescr`), which the
-    # reference Python `asdf` package relies on. Expected values below were verified against
-    # `np.ndarray(shape, dtype, buffer, offset, strides=None, order='C').strides`.
+    # 2026/08/06: Regression test for STScI Roman L2 `.asdf` products produced by romanisim,
+    # which contain `!core/ndarray` nodes (e.g. `chisq`/`dumo`) with a zero-length shape and
+    # no explicit `strides` key; see the default-strides comment in the `NDArray` outer
+    # constructor for the NumPy convention involved. Expected values below were verified
+    # against `np.ndarray(shape, dtype, buffer, offset, strides=None, order='C').strides`.
     cases = [
         (Int64[0, 0], ASDF.Datatype_float16, Int64[2, 2]),
         (Int64[0, 5], ASDF.Datatype_float32, Int64[20, 4]),

--- a/test/test-ndarray.jl
+++ b/test/test-ndarray.jl
@@ -113,6 +113,26 @@ end
     end
 end
 
+@testset "implicit strides with negative-shape elements" begin
+    # Regression test: the implicit-strides branch of
+    # the `NDArray` outer constructor clamps negative entries so the
+    # `strides` positivity check downstream can't misfire on them. That clamping only affects
+    # the temporary array used to compute `strides`; it must not suppress the `shape`
+    # negativity check in the inner constructor, which always receives the original,
+    # unclamped `shape`. Cover a negative element both outside (`shape[1]`) and inside
+    # (`shape[2:end]`) the slice passed to `max.(...)`.
+    for shape in (Int64[-1, 3], Int64[3, -1])
+        test_ndarray(
+            ArgumentError,
+            "`shape` cannot have negative elements.";
+            source = Int64(0),
+            data = nothing,
+            shape,
+            strides = nothing,
+        )
+    end
+end
+
 @testset "getindex" begin
     opposite = ASDF.host_byteorder == ASDF.Byteorder_little ? ASDF.Byteorder_big : ASDF.Byteorder_little
 

--- a/test/test-ndarray.jl
+++ b/test/test-ndarray.jl
@@ -100,21 +100,16 @@ end
         (Int64[0, 2, 3], ASDF.Datatype_float32, Int64[24, 12, 4]),
     ]
     for (shape, datatype, expected_strides) in cases
-        nd = ASDF.NDArray(
-            ASDF.LazyBlockHeaders(), Int64(0), nothing, shape, datatype, ASDF.host_byteorder, Int64(0), nothing,
-        )
-        @test nd.strides == expected_strides
-    end
-
-    @testset "materializes a zero-size block-backed array" begin
         lbh = ASDF.LazyBlockHeaders()
         push!(lbh.block_headers, make_block_header(UInt8[]))
-        nd = ASDF.NDArray(
-            lbh, Int64(0), nothing, Int64[0, 0], ASDF.Datatype_float16, ASDF.host_byteorder, Int64(0), nothing,
+        nd = make_ndarray(;
+            lazy_block_headers = lbh, source = Int64(0), data = nothing, shape, datatype, strides = nothing,
         )
+        @test nd.strides == expected_strides
+        # Materialize from an empty block to catch stride-check false positives at read time.
         arr = nd[]
-        @test size(arr) == (0, 0)
-        @test eltype(arr) == Float16
+        @test size(arr) == Tuple(reverse(shape))
+        @test eltype(arr) == Type(datatype)
     end
 end
 


### PR DESCRIPTION
Some STScI Roman L2 `.asdf` files produced with romanisim contain `!core/ndarray` nodes with a zero-length shape (e.g. the `chisq`/`dumo` arrays, shape `[0, 0]`) and no explicit `strides` key. ASDF.jl's implicit C-order stride formula (`stride[i] = itemsize * prod(shape[i+1:])`) collapses to zero for any outer dimension whose product includes a zero-length axis, which then failed the constructor's "strides must be positive" check.

NumPy avoids this by treating zero-length dimensions as length 1 only within the running product when computing default C-contiguous strides (`PyArray_NewFromDescr`). The Python `asdf` package relies on this. Here I reproduce that convention, and have verified it against NumPy's actual output for several representative shapes/dtypes.

I also relax the post-materialization stride sanity check in `getindex`: Julia's `reshape`/`reinterpret` don't preserve stride values along size-0 or size-1 axes (no adjacent elements to space apart), so the check now only compares strides for dimensions with more than one element.

I verified this patch on my local L2 `.asdf` files: all arrays materialize with correct shapes/dtypes, and pixel values match Python's `asdf` exactly (accounting for Julia's column-major vs. NumPy's row-major indexing convention).

I added regression tests in test/test-ndarray.jl covering the implicit stride computation for zero-length dimensions and materialization of a zero-size block-backed array. The rest of the tests also pass for me locally.

The comments are somewhat verbose so I'm happy if you want to cut them down to size.